### PR TITLE
Force Renovate lockfile-update strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,9 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["github>sourcegraph/renovate-config"],
-  "rangeStrategy": "lockfile-update",
+  "force": {
+    "rangeStrategy": "lockfile-update"
+  },
   "semanticCommits": false,
   "docker": {
     "enabled": true,


### PR DESCRIPTION
This overrides the various rangeStrategy definitions found within Sourcegraph's existing config preset.