### PR TITLE
fix: omit multiple hovers when using with basic-code-intel

### DIFF
--- a/extension/src/lsp-conversion.ts
+++ b/extension/src/lsp-conversion.ts
@@ -31,6 +31,7 @@ export function convertHover(hover: Hover | null): sourcegraph.Hover | null {
                 .filter(str => !!str.trim())
                 .join('\n\n---\n\n'),
         },
+        priority: 100, // take precedence over basic-code-intel and other fuzzy hovers
     }
 }
 


### PR DESCRIPTION
A nonnegative hover priority takes precedence over all negative hover priorities, so this means if there is a lang-typescript hover, the basic-code-intel hover will not show. Note that hover priorities will be removed in 3.0 (in https://github.com/sourcegraph/sourcegraph/pull/2039); this fix is only helpful for 3.0 beta.

fix https://github.com/sourcegraph/sourcegraph/issues/1938