### PR TITLE
Fall back to basic-code-intel when typescript.serverUrl is not set

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -4,6 +4,7 @@ import { URL as _URL, URLSearchParams as _URLSearchParams } from 'whatwg-url'
 Object.assign(_URL, self.URL)
 Object.assign(self, { URL: _URL, URLSearchParams: _URLSearchParams })
 
+import { activateOnFileExts as activateBasicCodeIntelOnFileExts } from '@sourcegraph/basic-code-intel'
 import { Tracer as LightstepTracer } from '@sourcegraph/lightstep-tracer-webworker'
 import {
     createMessageConnection,
@@ -89,6 +90,12 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
     const token = cancellationTokenSource.token
 
     const config = sourcegraph.configuration.get().value as LangTypescriptConfiguration
+
+    if (!config['typescript.serverUrl']) {
+        // Fall back to basic-code-intel behavior
+        return activateBasicCodeIntelOnFileExts(['ts', 'tsx', 'js', 'jsx'])(ctx)
+    }
+
     const tracer: Tracer = config['lightstep.token']
         ? new LightstepTracer({ access_token: config['lightstep.token'], component_name: 'ext-lang-typescript' })
         : new Tracer()

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "tslint": "^5.11.0"
   },
   "dependencies": {
+    "@sourcegraph/basic-code-intel": "^1.0.0",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/yarn.lock
+++ b/yarn.lock
@@ -743,6 +743,13 @@
   dependencies:
     symbol-observable "^1.2.0"
 
+"@sourcegraph/basic-code-intel@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-1.0.0.tgz#3e315936f4cd3132e5b837b944f6dcdad0b47a7e"
+  integrity sha512-fGYsUzNDx8kA4qbhg147RyaSsU4AX+kz2ywkBMNFqZ/7CsCFSrt7RAyaHB5Lv0vnlybi0x/rtS++CDGMkdW0FA==
+  dependencies:
+    rxjs "^6.3.3"
+
 "@sourcegraph/lightstep-tracer-webworker@^0.20.14-fork.3":
   version "0.20.14-fork.3"
   resolved "https://registry.npmjs.org/@sourcegraph/lightstep-tracer-webworker/-/lightstep-tracer-webworker-0.20.14-fork.3.tgz#b7bd235af1214da9d206731e5f4271dfd267dd57"


### PR DESCRIPTION
This uses the [@sourcegraph/basic-code-intel](https://www.npmjs.com/package/@sourcegraph/basic-code-intel) library to provide code intelligence powered by ctags + search when the serverUrl is not yet set.

There could probably be better messaging around this (e.g. a message in the console).