### PR TITLE
make typescript.serverUrl optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
       "title": "LangTypescriptConfiguration",
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "typescript.serverUrl"
-      ],
       "properties": {
         "lightstep.token": {
           "description": "The LightStep project token to use for tracing.",


### PR DESCRIPTION
If this configuration value is not set, the extension falls back to fuzzy mode. It not being set is not an error.