### PR TITLE
fix infinite loop when file lacks ancestor package.json

### DIFF
--- a/extension/src/dependencies.ts
+++ b/extension/src/dependencies.ts
@@ -186,7 +186,7 @@ export async function findClosestPackageJson(
             rootUri = new URL(rootUri.href)
             rootUri.username = ''
             while (true) {
-                if (!parent.href.startsWith(rootUri.href)) {
+                if (!parent.href.startsWith(rootUri.href) || parent.href === rootUri.href) {
                     throw new Error(`No package.json found for ${resource} under root ${rootUri}`)
                 }
                 const packageJsonUri = new URL('package.json', parent.href)


### PR DESCRIPTION
If a JavaScript or TypeScript file has no ancestor package.json, the extension will enter an infinite loop requesting `http://localhost:3080/package.json` (where `http://localhost:3080` is the Sourcegraph URL). This means hundreds/thousands of requests within just a few seconds after loading. This occurs because it gets into a situation where `parent.href` and `rootUri.href` are both `http://localhost:3080/`, so the loop while-condition is always true, and subsequent iterations don't change the value of `parent.href`.

Repro at http://localhost:3080/github.com/Microsoft/TypeScriptSamples/-/blob/interfaces/interfaces.ts#L11:22&tab=references (with the TypeScript language server enabled and that repository added). I was unable to reproduce this at https://sourcegraph.com/github.com/Microsoft/TypeScriptSamples/-/blob/interfaces/interfaces.ts#L11:22&tab=references.