### PR TITLE
hide panel/toolbar action "References: Search mode" on irrelevant panels

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "panel/toolbar": [
         {
           "action": "impreciseResults",
-          "when": "isImprecise"
+          "when": "isImprecise && panel.activeView.hasLocations"
         }
       ]
     },


### PR DESCRIPTION
The "References: Search mode" action was showing up on other panels, such as Git history and (if enabled) code discussions. This makes it so they only show up on the appropriate panels.

Related: https://github.com/sourcegraph/sourcegraph-go/pull/48

![tswrongbutton](https://user-images.githubusercontent.com/1976/54484995-88a94180-482e-11e9-97d2-8882b51a73e5.png)
