### PR TITLE
Update link to generate self signed cert docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ To enable the use of Websocket with SSL pass the key/certificate pair as environ
 docker run -p 8080:8080 -e TLS_KEY="$(cat sourcegraph.example.com.key)" -e TLS_CERT="$(cat sourcegraph.example.com.crt)" sourcegraph/lang-typescript
 ```
 
-To reuse the self-signed certificate created by following the steps [here](https://docs.sourcegraph.com/admin/nginx#tls-https) add these parameters to the run command above:
+To reuse the self-signed certificate created by following the steps [here](https://docs.sourcegraph.com/admin/nginx#if-you-need-an-ssl-certificate) add these parameters to the run command above:
 
 ```
 -e NODE_EXTRA_CA_CERTS=/home/node/sourcegraph.example.com.crt -v ~/.sourcegraph/config:/home/node


### PR DESCRIPTION
Sourcegraph's docs around HTTPS have been modified. Updating the link in this doc to take the user to SSL generation section of the Sourcegraph's modified docs.