### PR TITLE
Filter definitions by imports in basic-code-intel mode

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -123,7 +123,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     .split('\n')
                     .map(line => {
                         // Matches the import at index 1
-                        const match = /from ['"](.*)['"];?$/.exec(line) || /require\(['"](.*)['"]\);?$/.exec(line)
+                        const match = /\bfrom ['"](.*)['"];?$/.exec(line) || /\brequire\(['"](.*)['"]\)/.exec(line)
                         return match ? match[1] : undefined
                     })
                     .filter((x): x is string => Boolean(x))

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -78,6 +78,8 @@ import {
     throwIfAbortError,
 } from './util'
 
+const path = require('path-browserify')
+
 const HOVER_DEF_POLL_INTERVAL = 2000
 const EXTERNAL_REFS_CONCURRENCY = 7
 
@@ -108,15 +110,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
         return activateBasicCodeIntel({
             languageID: 'typescript',
             fileExts: ['ts', 'tsx', 'js', 'jsx'],
-            definitionPatterns: [
-                'var\\s\\b%s\\b',
-                'let\\s\\b%s\\b',
-                'const\\s\\b%s\\b',
-                'function\\s\\b%s\\b',
-                'interface\\s\\b%s\\b',
-                'type\\s\\b%s\\b',
-                '\\b%s\\b:',
-            ],
             commentStyle: {
                 lineRegex: /\/\/\s?/,
                 block: {
@@ -124,6 +117,22 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     lineNoiseRegex: /(^\s*\*\s?)?/,
                     endRegex: /\*\//,
                 },
+            },
+            filterDefinitions: ({ filePath, fileContent, results }) => {
+                const imports = fileContent
+                    .split('\n')
+                    .map(line => {
+                        // Matches the import at index 1
+                        const match = /from ['"](.*)['"];?$/.exec(line) || /require\(['"](.*)['"]\);?$/.exec(line)
+                        return match ? match[1] : undefined
+                    })
+                    .filter((x): x is string => Boolean(x))
+
+                const filteredResults = results.filter(result =>
+                    imports.some(i => path.join(path.dirname(filePath), i) === result.file.replace(/\.[^/.]+$/, ''))
+                )
+
+                return filteredResults.length === 0 ? results : filteredResults
             },
         })(ctx)
     }

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^6.0.7",
+    "@sourcegraph/basic-code-intel": "^6.0.12",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",
@@ -216,6 +216,7 @@
     "mz": "^2.7.0",
     "npm-registry-fetch": "^3.8.0",
     "opentracing": "^0.14.3",
+    "path-browserify": "^1.0.0",
     "pretty-bytes": "^5.1.0",
     "prom-client": "^11.2.0",
     "relateurl": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^6.0.12",
+    "@sourcegraph/basic-code-intel": "^6.0.13",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,14 +714,15 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^6.0.7":
-  version "6.0.7"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.7.tgz#6ba8623c1c5e71f780a059ccea2120ffdc1e3600"
-  integrity sha512-+amGIq54N3aVOj7AxNtW6QtDfUVvtT253Ha+i9sofyo217L/7Ucwo/WoDGuded9Ng9FUxUM6UOS3MREW+lkUGQ==
+"@sourcegraph/basic-code-intel@^6.0.12":
+  version "6.0.12"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.12.tgz#5d6c1a301c73a19bf28f6d25b5f4846cc3db844f"
+  integrity sha512-G8IUx29UV1asiU3SZ3AMYKlZSZxX63nC7IR4ux+Jd+TBg2OW9WrRKOEaYKp2MWlwyWBc7Dpix3hv6GqMSMJNyA==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
+    sprintf-js "^1.1.2"
 
 "@sourcegraph/lightstep-tracer-webworker@^0.20.14-fork.3":
   version "0.20.14-fork.3"
@@ -5056,6 +5057,11 @@ path-browserify@0.0.0:
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
   integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
+path-browserify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz#40702a97af46ae00b0ea6fa8998c0b03c0af160d"
+  integrity sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==
+
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
@@ -6366,6 +6372,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,15 +714,14 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^6.0.12":
-  version "6.0.12"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.12.tgz#5d6c1a301c73a19bf28f6d25b5f4846cc3db844f"
-  integrity sha512-G8IUx29UV1asiU3SZ3AMYKlZSZxX63nC7IR4ux+Jd+TBg2OW9WrRKOEaYKp2MWlwyWBc7Dpix3hv6GqMSMJNyA==
+"@sourcegraph/basic-code-intel@^6.0.13":
+  version "6.0.13"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.13.tgz#1fa7030d4b5813c8ede3a51dacd81647dd33edee"
+  integrity sha512-psxFy4lj8A8kRH2WMGFam0y1+VrBQqIgrOrTyH6At27Qpxwuz6OlHkKzTBUnc9HqNDkxGAEIuUSx5kMuLYoK4g==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
     sourcegraph "^23.0.0"
-    sprintf-js "^1.1.2"
 
 "@sourcegraph/lightstep-tracer-webworker@^0.20.14-fork.3":
   version "0.20.14-fork.3"
@@ -6372,11 +6371,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-sprintf-js@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
-  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
This scans the file for `import`s or `require`s and filters definitions to ones that are defined in one of the imported files. If none match, the constraint is lifted.

![image](https://user-images.githubusercontent.com/1387653/54884570-edb4f680-4e2f-11e9-806b-a93c2f409934.png)

Corresponds to https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/77