### PR TITLE
Fall back to basic-code-intel after 500ms

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^6.0.13",
+    "@sourcegraph/basic-code-intel": "^6.0.14",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,10 +714,10 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^6.0.13":
-  version "6.0.13"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.13.tgz#1fa7030d4b5813c8ede3a51dacd81647dd33edee"
-  integrity sha512-psxFy4lj8A8kRH2WMGFam0y1+VrBQqIgrOrTyH6At27Qpxwuz6OlHkKzTBUnc9HqNDkxGAEIuUSx5kMuLYoK4g==
+"@sourcegraph/basic-code-intel@^6.0.14":
+  version "6.0.14"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.14.tgz#898216e8966d1b902c5e49199a2a33d255ed9de4"
+  integrity sha512-SekYreQAgpmeE4oNWh+Dke6ChXwudLyr+5qU79DX6lSQY1UQLg55T5cmwSbcIBLKwQzvyyUJ7YLvtQhXOn7QwA==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"


### PR DESCRIPTION
How it works: the language server request gets kicked off immediately. If it doesn't respond in less than 500ms, basic code intel gets kicked off. Whichever responds first wins, and the other is ignored until the next hover/def/ref call.

Same approach as https://github.com/sourcegraph/sourcegraph-go/pull/55

Resolves https://github.com/sourcegraph/sourcegraph-typescript/issues/107