### PR TITLE
Remove path-browserify

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -20,6 +20,7 @@ import { merge } from 'ix/asynciterable/index'
 import { filter, map, scan, tap } from 'ix/asynciterable/pipe/index'
 import { fromPairs } from 'lodash'
 import { Span, Tracer } from 'opentracing'
+import * as path from 'path'
 import { BehaviorSubject, from, fromEventPattern, Subscription } from 'rxjs'
 import * as rxop from 'rxjs/operators'
 import * as sourcegraph from 'sourcegraph'
@@ -77,8 +78,6 @@ import {
     SourcegraphEndpoint,
     throwIfAbortError,
 } from './util'
-
-const path = require('path-browserify')
 
 const HOVER_DEF_POLL_INTERVAL = 2000
 const EXTERNAL_REFS_CONCURRENCY = 7

--- a/package.json
+++ b/package.json
@@ -216,7 +216,6 @@
     "mz": "^2.7.0",
     "npm-registry-fetch": "^3.8.0",
     "opentracing": "^0.14.3",
-    "path-browserify": "^1.0.0",
     "pretty-bytes": "^5.1.0",
     "prom-client": "^11.2.0",
     "relateurl": "^0.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5056,11 +5056,6 @@ path-browserify@0.0.0:
   resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
   integrity sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=
 
-path-browserify@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.0.tgz#40702a97af46ae00b0ea6fa8998c0b03c0af160d"
-  integrity sha512-Hkavx/nY4/plImrZPHRk2CL9vpOymZLgEbMNX1U0bjcBL7QN9wODxyx0yaMZURSQaUtSEvDrfAvxa9oPb0at9g==
-
 path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"


### PR DESCRIPTION
Context: https://github.com/sourcegraph/sourcegraph-typescript/pull/139#discussion_r269244637

I did not get any errors with using `import * as path from 'path'`. Using `require()` makes every interaction with `path` not type safe because it is type `any`.