### PR TITLE
Add LSIF support

### DIFF
--- a/extension/src/basic-code-intel.ts
+++ b/extension/src/basic-code-intel.ts
@@ -1,0 +1,47 @@
+import { Handler } from '@sourcegraph/basic-code-intel'
+import * as path from 'path'
+import * as sourcegraph from 'sourcegraph'
+
+export interface Providers {
+    hover: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Hover | null>
+    definition: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Definition | null>
+    references: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Location[] | null>
+}
+
+export function initBasicCodeIntel(): Providers {
+    const handler = new Handler({
+        sourcegraph,
+        languageID: 'typescript',
+        fileExts: ['ts', 'tsx', 'js', 'jsx'],
+        commentStyle: {
+            lineRegex: /\/\/\s?/,
+            block: {
+                startRegex: /\/\*\*?/,
+                lineNoiseRegex: /(^\s*\*\s?)?/,
+                endRegex: /\*\//,
+            },
+        },
+        filterDefinitions: ({ filePath, fileContent, results }) => {
+            const imports = fileContent
+                .split('\n')
+                .map(line => {
+                    // Matches the import at index 1
+                    const match = /\bfrom ['"](.*)['"];?$/.exec(line) || /\brequire\(['"](.*)['"]\)/.exec(line)
+                    return match ? match[1] : undefined
+                })
+                .filter((x): x is string => Boolean(x))
+
+            const filteredResults = results.filter(result =>
+                imports.some(i => path.join(path.dirname(filePath), i) === result.file.replace(/\.[^/.]+$/, ''))
+            )
+
+            return filteredResults.length === 0 ? results : filteredResults
+        },
+    })
+
+    return {
+        hover: handler.hover.bind(handler),
+        definition: handler.definition.bind(handler),
+        references: handler.references.bind(handler),
+    }
+}

--- a/extension/src/basic-code-intel.ts
+++ b/extension/src/basic-code-intel.ts
@@ -1,15 +1,9 @@
-import { Handler } from '@sourcegraph/basic-code-intel'
+import { Handler, Providers } from '@sourcegraph/basic-code-intel'
 import * as path from 'path'
 import * as sourcegraph from 'sourcegraph'
 
-export interface Providers {
-    hover: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Hover | null>
-    definition: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Definition | null>
-    references: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Location[] | null>
-}
-
 export function initBasicCodeIntel(): Providers {
-    const handler = new Handler({
+    return new Handler({
         sourcegraph,
         languageID: 'typescript',
         fileExts: ['ts', 'tsx', 'js', 'jsx'],
@@ -38,10 +32,4 @@ export function initBasicCodeIntel(): Providers {
             return filteredResults.length === 0 ? results : filteredResults
         },
     })
-
-    return {
-        hover: handler.hover.bind(handler),
-        definition: handler.definition.bind(handler),
-        references: handler.references.bind(handler),
-    }
 }

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -6,8 +6,7 @@ import { URL as _URL, URLSearchParams as _URLSearchParams } from 'whatwg-url'
 Object.assign(_URL, self.URL)
 Object.assign(self, { URL: _URL, URLSearchParams: _URLSearchParams })
 
-import { initLSIF } from '@sourcegraph/basic-code-intel'
-import { mkIsLSIFAvailable } from '@sourcegraph/basic-code-intel/lib/lsif'
+import { initLSIF, mkIsLSIFAvailable } from '@sourcegraph/basic-code-intel'
 import { Tracer as LightstepTracer } from '@sourcegraph/lightstep-tracer-webworker'
 import {
     createMessageConnection,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -48,7 +48,7 @@ import {
     TextDocumentPositionParams,
 } from 'vscode-languageserver-protocol'
 import { getOrCreateAccessToken } from './auth'
-import { initBasicCodeIntel } from './basic-code-intel';
+import { initBasicCodeIntel } from './basic-code-intel'
 import { LangTypescriptConfiguration } from './config'
 import {
     findPackageDependentsWithNpm,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -92,19 +92,6 @@ import { mkIsLSIFAvailable } from '@sourcegraph/basic-code-intel/lib/lsif'
 const HOVER_DEF_POLL_INTERVAL = 2000
 const EXTERNAL_REFS_CONCURRENCY = 7
 
-const getConfig = () =>
-    sourcegraph.configuration.get().value as LangTypescriptConfiguration & { 'codeIntel.lsif': boolean }
-
-type NonDisposableMessageConnection = Omit<MessageConnection, 'dispose'>
-
-const connectionsByRootUri = new Map<string, Promise<NonDisposableMessageConnection>>()
-
-const isTypeScriptFile = (textDocumentUri: URL): boolean => /\.m?(?:t|j)sx?$/.test(textDocumentUri.hash)
-
-const documentSelector: sourcegraph.DocumentSelector = [{ language: 'typescript' }, { language: 'javascript' }]
-
-const logger: Logger = new RedactingLogger(console)
-
 interface Providers {
     hover: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Hover | null>
     definition: (doc: sourcegraph.TextDocument, pos: sourcegraph.Position) => Promise<sourcegraph.Definition | null>
@@ -148,6 +135,19 @@ function initBasicCodeIntel(): Providers {
         references: handler.references.bind(handler),
     }
 }
+
+const getConfig = () =>
+    sourcegraph.configuration.get().value as LangTypescriptConfiguration & { 'codeIntel.lsif': boolean }
+
+type NonDisposableMessageConnection = Omit<MessageConnection, 'dispose'>
+
+const connectionsByRootUri = new Map<string, Promise<NonDisposableMessageConnection>>()
+
+const isTypeScriptFile = (textDocumentUri: URL): boolean => /\.m?(?:t|j)sx?$/.test(textDocumentUri.hash)
+
+const documentSelector: sourcegraph.DocumentSelector = [{ language: 'typescript' }, { language: 'javascript' }]
+
+const logger: Logger = new RedactingLogger(console)
 
 export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void> {
     logger.log('TypeScript extension activated')

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -6,7 +6,7 @@ import { URL as _URL, URLSearchParams as _URLSearchParams } from 'whatwg-url'
 Object.assign(_URL, self.URL)
 Object.assign(self, { URL: _URL, URLSearchParams: _URLSearchParams })
 
-import { activateBasicCodeIntel, registerFeedbackButton } from '@sourcegraph/basic-code-intel'
+import { activateBasicCodeIntel } from '@sourcegraph/basic-code-intel'
 import { Tracer as LightstepTracer } from '@sourcegraph/lightstep-tracer-webworker'
 import {
     createMessageConnection,
@@ -118,14 +118,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
         logger.warn('No typescript.serverUrl configured, falling back to basic code intelligence')
         // Fall back to basic-code-intel behavior
 
-        ctx.subscriptions.add(
-            registerFeedbackButton({
-                languageID: 'typescript',
-                sourcegraph,
-                isPrecise: false,
-            })
-        )
-
         return activateBasicCodeIntel({
             sourcegraph,
             languageID: 'typescript',
@@ -156,8 +148,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
             },
         })(ctx)
     }
-
-    ctx.subscriptions.add(registerFeedbackButton({ languageID: 'typescript', sourcegraph, isPrecise: true }))
 
     const tracer: Tracer = config.value['lightstep.token']
         ? new LightstepTracer({ access_token: config.value['lightstep.token'], component_name: 'ext-lang-typescript' })

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -819,17 +819,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                 rewriteUris(implementationResult, toSourcegraphTextDocumentUri)
                 return convertLocations(implementationResult)
             })
-        // Use both old registerImplementationProvider (pre-3.2) and registerLocationProvider (3.2+)
-        // for backcompat and forward-compat. This yields a deprecation console.warn on 3.2+. It is
-        // not possible to just use registerLocationProvider without breaking this functionality
-        // because of the bug fixed in 3.2 by https://github.com/sourcegraph/sourcegraph/pull/2733
-        // affects pre-3.2 versions. The registerImplementationProvider call can be removed when
-        // supporting backcompat for pre-3.2 is no longer needed.
-        providers.add(
-            sourcegraph.languages.registerImplementationProvider(documentSelector, {
-                provideImplementation: provideImpls,
-            })
-        )
         providers.add(
             sourcegraph.languages.registerLocationProvider(IMPL_ID, documentSelector, {
                 provideLocations: provideImpls,

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -464,11 +464,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         return
                     }
 
-                    // This dummy arg will not be necessary once
-                    // https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/132
-                    // is merged.
-                    const dummyPosition = new sourcegraph.Position(0, 0)
-                    if (!(await isLSIFAvailable(textDocument, dummyPosition)) && config.value['typescript.serverUrl']) {
+                    if (!(await isLSIFAvailable(textDocument)) && config.value['typescript.serverUrl']) {
                         const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
                         const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
                         const connection = await getOrCreateConnection(serverRootUri, { token, span })
@@ -513,7 +509,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('Hover trace', span.generateTraceURL())
                 }
 
-                if (await isLSIFAvailable(textDocument, position)) {
+                if (await isLSIFAvailable(textDocument)) {
                     const lsifResult = await lsif.hover(textDocument, position)
                     yield lsifResult && lsifResult.value
                 } else if (!config.value['typescript.serverUrl']) {
@@ -558,7 +554,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         logger.log('Definition trace', span.generateTraceURL())
                     }
 
-                    if (await isLSIFAvailable(textDocument, position)) {
+                    if (await isLSIFAvailable(textDocument)) {
                         const lsifResult = await lsif.definition(textDocument, position)
                         yield lsifResult ? lsifResult.value : null
                     } else if (!config.value['typescript.serverUrl']) {
@@ -605,7 +601,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('References trace', span.generateTraceURL())
                 }
 
-                if (await isLSIFAvailable(textDocument, position)) {
+                if (await isLSIFAvailable(textDocument)) {
                     const lsifResult = await lsif.references(textDocument, position)
                     yield (lsifResult && lsifResult.value) || []
                 } else if (!config.value['typescript.serverUrl']) {
@@ -811,7 +807,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         logger.log('Implementation trace', span.generateTraceURL())
                     }
 
-                    if (await isLSIFAvailable(textDocument, position)) {
+                    if (await isLSIFAvailable(textDocument)) {
                         return null
                     }
 

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^6.0.18",
+    "@sourcegraph/basic-code-intel": "^7.0.3",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^7.0.3",
+    "@sourcegraph/basic-code-intel": "^7.0.4",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "yarn-deduplicate": "^1.1.1"
   },
   "dependencies": {
-    "@sourcegraph/basic-code-intel": "^7.0.4",
+    "@sourcegraph/basic-code-intel": "^7.0.5",
     "@sourcegraph/lightstep-tracer-webworker": "^0.20.14-fork.3",
     "@sourcegraph/typescript-language-server": "^0.3.7-fork",
     "@sourcegraph/vscode-ws-jsonrpc": "0.0.3-fork",

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,10 +722,10 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.3.tgz#078c100d2a0a635cc6082091718dc689b8cc113b"
-  integrity sha512-BI5bTHUkNpIPIshBg/pxOuNVarO8Dt7TlF+8c1Zpz4uqdCzufxxtkY2OPVQ/KehlJepMJiuPFmrvHrUN19p51g==
+"@sourcegraph/basic-code-intel@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.4.tgz#1807edea0014404ea4d2d60bdd943505e167f1a4"
+  integrity sha512-+SpmHSg3eZAli91tpIGlLmdujYaYH0bvXzx71T+bQ+fFkuJibASm/725IwLUa5jG/AyuaT7K1zar51Fbdp976Q==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,10 +722,10 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^7.0.4":
-  version "7.0.4"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.4.tgz#1807edea0014404ea4d2d60bdd943505e167f1a4"
-  integrity sha512-+SpmHSg3eZAli91tpIGlLmdujYaYH0bvXzx71T+bQ+fFkuJibASm/725IwLUa5jG/AyuaT7K1zar51Fbdp976Q==
+"@sourcegraph/basic-code-intel@^7.0.5":
+  version "7.0.5"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.5.tgz#eb17ef2a29e4fe3a935a9cf8b385d3737fa64148"
+  integrity sha512-FmGIdATsr9hvIivvJ4yu216YiyPbQn4+lPTe0eKlbIXM5eTK5OUgVSIH57wAeAkCvscy/Jzg03d8rqmkAFtz8g==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6350,10 +6350,10 @@ source-map@^0.7.3:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-sourcegraph@^23.0.0:
-  version "23.0.0"
-  resolved "https://registry.npmjs.org/sourcegraph/-/sourcegraph-23.0.0.tgz#1fb96015af3e84cc9cc2944823f04a7e952ed565"
-  integrity sha512-hQALHrTt+AK5ZAqUAUNhxO7ClSv/xyTjMQPBb+hQykKJrMaHTk+CnJNHs7dRfXYKnbnZeisQRjaxKGX8UecU0Q==
+sourcegraph@^23.0.0, sourcegraph@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.npmjs.org/sourcegraph/-/sourcegraph-23.0.1.tgz#715fcf4129a6d94bc3bfd2740d9c706ae6357ffe"
+  integrity sha512-4We7zqhOagOVxNFdS6/xT/Crhb0Arw/9ytGBu8JuHfjo5yjMtcUYt22kZyu2TaPHXwyPW9muUi1eKSFA6Qg4lw==
 
 spdx-correct@^3.0.0:
   version "3.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -722,14 +722,15 @@
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
-"@sourcegraph/basic-code-intel@^6.0.18":
-  version "6.0.18"
-  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-6.0.18.tgz#ca8a658213bab7295b98619af5623c51d39b6ea8"
-  integrity sha512-PE9mWg/HNBesShKZrILVtxF2VQjtQ9nV9DHECvqqiJ70savcRphcpAmdpPICFvqh5GxYUIoRo3AkzdPGI0DUjw==
+"@sourcegraph/basic-code-intel@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/@sourcegraph/basic-code-intel/-/basic-code-intel-7.0.3.tgz#078c100d2a0a635cc6082091718dc689b8cc113b"
+  integrity sha512-BI5bTHUkNpIPIshBg/pxOuNVarO8Dt7TlF+8c1Zpz4uqdCzufxxtkY2OPVQ/KehlJepMJiuPFmrvHrUN19p51g==
   dependencies:
     lodash "^4.17.11"
     rxjs "^6.3.3"
-    sourcegraph "^23.0.0"
+    sourcegraph "^23.0.1"
+    vscode-languageserver-types "^3.14.0"
 
 "@sourcegraph/lightstep-tracer-webworker@^0.20.14-fork.3":
   version "0.20.14-fork.3"
@@ -7181,7 +7182,7 @@ vscode-languageserver-protocol@^3.10.3, vscode-languageserver-protocol@^3.13.0:
     vscode-jsonrpc "^4.0.0"
     vscode-languageserver-types "3.14.0"
 
-vscode-languageserver-types@3.14.0, vscode-languageserver-types@^3.13.0:
+vscode-languageserver-types@3.14.0, vscode-languageserver-types@^3.13.0, vscode-languageserver-types@^3.14.0:
   version "3.14.0"
   resolved "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
   integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==


### PR DESCRIPTION
Resolves https://github.com/sourcegraph/sourcegraph/issues/5008

This adds LSIF support to the TypeScript extension. Here's the behavior:

- When `codeIntel.lsif` is `true`: use LSIF but fall back to basic-code-intel when LSIF data doesn't exist
- Otherwise when `typescript.serverUrl` is not set: only use basic-code-intel
- Otherwise `typescript.serverUrl` must be set, so use the language server

Due to the amount of time it would take to implement and considering that we're migrating away from language servers (see the [roadmap](https://docs.google.com/document/d/1JAbq58Tp-3R2oahkYB9fnHBjlOTSqEEmrp8T66tmHfQ/edit#heading=h.r6zmhuup0vm3)), this isn't quite the same as the other language extensions, which fall back in this order: 1. LSIF 2. language server 3. basic-code-intel