### PR TITLE
Fix basic code intel definitions

### DIFF
--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -584,7 +584,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
         providers.add(
             sourcegraph.languages.registerDefinitionProvider(documentSelector, {
                 provideDefinition: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-                    observableFromAsyncIterable(provideDefinition(textDocument, position))
+                    observableFromAsyncIterable(provideDefinition(textDocument, position)).pipe(rxop.shareReplay(1))
                 ),
             })
         )

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -540,7 +540,7 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
         providers.add(
             sourcegraph.languages.registerHoverProvider(documentSelector, {
                 provideHover: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-                    observableFromAsyncIterable(provideHover(textDocument, position))
+                    observableFromAsyncIterable(provideHover(textDocument, position)).pipe(rxop.shareReplay(1))
                 ),
             })
         )


### PR DESCRIPTION
The problem seems to be that the Observable returned by `provideDefinition` and wrapped by `distinctUntilChanged` is hot, was emitting exactly once, and was emitting before the Sourcegraph extension API called `provideDefinition` a second time. On the second call, `distinctUntilChanged` returned the cached Observable which was done emitting and ended up preventing any location results from getting to the Sourcegraph extension API.

It seems as though https://github.com/sourcegraph/sourcegraph/issues/1321 is either not actually fixed, or the double-call has reappeared.

Fixes https://github.com/sourcegraph/sourcegraph/issues/5620

cc @sourcegraph/code-intel 