### PR TITLE
Fix package.json serve-ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "build-ts": "yarn run config-types && tsc -b .",
     "watch-ts": "yarn run config-types && tsc -b . -w",
     "build": "yarn run build-ts && parcel build --out-file extension.js src/extension/extension.ts && dot-json dist/extension.map sourceRoot https://sourcegraph.com/github.com/sourcegraph/sourcegraph-typescript@$(git rev-parse HEAD)/-/raw/extension/src/",
-    "serve-ext": "yarn run symlink-package && yarn run build-ts && parcel serve --no-hmr --out-file dist/extension.js extension/src/extension.ts",
+    "serve-ext": "yarn run symlink-package && yarn run build-ts && parcel serve --no-hmr --out-file dist/extension.js src/extension/extension.ts",
     "symlink-package": "mkdirp dist && lnfs ./package.json ./dist/package.json",
     "sourcegraph:prepublish": "yarn run build"
   },


### PR DESCRIPTION
Mirrors https://github.com/sourcegraph/sourcegraph-typescript/commit/80a9112705d8caa6ebfc01c2ede44341c33b6c97#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L173-R173