### PR TITLE
Activation refactor

### DIFF
--- a/src/common/cancellation.ts
+++ b/src/common/cancellation.ts
@@ -1,25 +1,7 @@
 import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc'
+import { createAbortError } from '@sourcegraph/basic-code-intel'
 
-export interface AbortError extends Error {
-    name: 'AbortError'
-}
-
-/**
- * Creates an Error with name "AbortError"
- */
-export const createAbortError = (): AbortError => Object.assign(new Error('Aborted'), { name: 'AbortError' as const })
-
-/**
- * Returns true if the given value is an AbortError
- */
-export const isAbortError = (err: any): err is AbortError =>
-    typeof err === 'object' && err !== null && err.name === 'AbortError'
-
-export function throwIfAbortError(err: unknown): void {
-    if (isAbortError(err)) {
-        throw err
-    }
-}
+export { AbortError, createAbortError, isAbortError, throwIfAbortError } from '@sourcegraph/basic-code-intel'
 
 /**
  * Throws an AbortError if the given AbortSignal is already aborted

--- a/src/common/cancellation.ts
+++ b/src/common/cancellation.ts
@@ -1,7 +1,7 @@
 import { CancellationToken, CancellationTokenSource } from 'vscode-jsonrpc'
+export { AbortError, isAbortError, throwIfAbortError } from '@sourcegraph/basic-code-intel'
 import { createAbortError } from '@sourcegraph/basic-code-intel'
-
-export { AbortError, createAbortError, isAbortError, throwIfAbortError } from '@sourcegraph/basic-code-intel'
+export { createAbortError }
 
 /**
  * Throws an AbortError if the given AbortSignal is already aborted

--- a/src/extension/basic-code-intel.ts
+++ b/src/extension/basic-code-intel.ts
@@ -1,35 +1,33 @@
-import { Handler, Providers } from '@sourcegraph/basic-code-intel'
+import { HandlerArgs } from '@sourcegraph/basic-code-intel'
 import * as path from 'path'
 import * as sourcegraph from 'sourcegraph'
 
-export function initBasicCodeIntel(): Providers {
-    return new Handler({
-        sourcegraph,
-        languageID: 'typescript',
-        fileExts: ['ts', 'tsx', 'js', 'jsx'],
-        commentStyle: {
-            lineRegex: /\/\/\s?/,
-            block: {
-                startRegex: /\/\*\*?/,
-                lineNoiseRegex: /(^\s*\*\s?)?/,
-                endRegex: /\*\//,
-            },
+export const handlerArgs: HandlerArgs = {
+    sourcegraph,
+    languageID: 'typescript',
+    fileExts: ['ts', 'tsx', 'js', 'jsx'],
+    commentStyle: {
+        lineRegex: /\/\/\s?/,
+        block: {
+            startRegex: /\/\*\*?/,
+            lineNoiseRegex: /(^\s*\*\s?)?/,
+            endRegex: /\*\//,
         },
-        filterDefinitions: ({ filePath, fileContent, results }) => {
-            const imports = fileContent
-                .split('\n')
-                .map(line => {
-                    // Matches the import at index 1
-                    const match = /\bfrom ['"](.*)['"];?$/.exec(line) || /\brequire\(['"](.*)['"]\)/.exec(line)
-                    return match ? match[1] : undefined
-                })
-                .filter((x): x is string => Boolean(x))
+    },
+    filterDefinitions: ({ filePath, fileContent, results }) => {
+        const imports = fileContent
+            .split('\n')
+            .map(line => {
+                // Matches the import at index 1
+                const match = /\bfrom ['"](.*)['"];?$/.exec(line) || /\brequire\(['"](.*)['"]\)/.exec(line)
+                return match ? match[1] : undefined
+            })
+            .filter((x): x is string => Boolean(x))
 
-            const filteredResults = results.filter(result =>
-                imports.some(i => path.join(path.dirname(filePath), i) === result.file.replace(/\.[^/.]+$/, ''))
-            )
+        const filteredResults = results.filter(result =>
+            imports.some(i => path.join(path.dirname(filePath), i) === result.file.replace(/\.[^/.]+$/, ''))
+        )
 
-            return filteredResults.length === 0 ? results : filteredResults
-        },
-    })
+        return filteredResults.length === 0 ? results : filteredResults
+    },
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -768,16 +768,23 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                 yield convertLocations(implementationResult)
             })
 
-        activateCodeIntel(ctx, documentSelector, handlerArgs, {
-            definition: provideDefinition,
-            references: provideReferences,
-            hover: provideHover,
-            implementations: {
-                implId: 'ts.impl',
-                panelTitle: 'Implementations',
-                locations: provideImpls,
-            },
-        })
+        activateCodeIntel(
+            ctx,
+            documentSelector,
+            handlerArgs,
+            config.value['typescript.serverUrl']
+                ? {
+                      definition: provideDefinition,
+                      references: provideReferences,
+                      hover: provideHover,
+                      implementations: {
+                          implId: 'ts.impl',
+                          panelTitle: 'Implementations',
+                          locations: provideImpls,
+                      },
+                  }
+                : undefined
+        )
     }
 }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -503,37 +503,37 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                 }
 
                 // const lsifResult = await lsif.hover(textDocument, position)
-                // if (lsifResult) {
-                //     yield lsifResult.value
-                // } else if (!config.value['typescript.serverUrl']) {
-                //     const result = await basicCodeIntel.hover(textDocument, position)
-                //     if (result) {
-                //         yield { ...result, badge: impreciseBadge }
-                //     } else {
-                //         yield undefined
-                //     }
-                // } else {
-                const textDocumentUri = new URL(textDocument.uri)
-                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                if (false) {
+                    //     yield lsifResult.value
+                    // } else if (!config.value['typescript.serverUrl']) {
+                    //     const result = await basicCodeIntel.hover(textDocument, position)
+                    //     if (result) {
+                    //         yield { ...result, badge: impreciseBadge }
+                    //     } else {
+                    //         yield undefined
+                    //     }
+                } else {
+                    const textDocumentUri = new URL(textDocument.uri)
+                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                // Poll server to get updated results when e.g. dependency installation finished
-                while (true) {
-                    const hoverResult = await sendTracedRequest(
-                        connection,
-                        HoverRequest.type,
-                        {
-                            textDocument: { uri: serverTextDocumentUri.href },
-                            position,
-                        },
-                        { span, tracer, token }
-                    )
-                    rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
-                    yield convertHover(hoverResult)
-                    await delayPromise(HOVER_DEF_POLL_INTERVAL)
+                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                    // Poll server to get updated results when e.g. dependency installation finished
+                    while (true) {
+                        const hoverResult = await sendTracedRequest(
+                            connection,
+                            HoverRequest.type,
+                            {
+                                textDocument: { uri: serverTextDocumentUri.href },
+                                position,
+                            },
+                            { span, tracer, token }
+                        )
+                        rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
+                        yield convertHover(hoverResult)
+                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
+                    }
                 }
-                // }
             })
         )
         // providers.add(
@@ -555,40 +555,40 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     }
 
                     // const lsifResult = await lsif.definition(textDocument, position)
-                    // if (lsifResult) {
-                    //     yield lsifResult.value
-                    // } else if (!config.value['typescript.serverUrl']) {
-                    //     const result = await basicCodeIntel.definition(textDocument, position)
-                    //     if (result) {
-                    //         if (Array.isArray(result)) {
-                    //             yield result.map(v => ({ ...v, badge: impreciseBadge }))
-                    //         } else {
-                    //             yield { ...result, badge: impreciseBadge }
-                    //         }
-                    //     } else {
-                    //         yield undefined
-                    //     }
-                    // } else {
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                    // Poll server to get updated contents when e.g. dependency installation finished
-                    while (true) {
-                        const definitionResult = (await sendTracedRequest(
-                            connection,
-                            DefinitionRequest.type,
-                            {
-                                textDocument: { uri: serverTextDocumentUri.href },
-                                position,
-                            },
-                            { span, tracer, token }
-                        )) as Location[] | Location | null
-                        rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
-                        yield convertLocations(definitionResult)
-                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
+                    if (false) {
+                        //     yield lsifResult.value
+                        // } else if (!config.value['typescript.serverUrl']) {
+                        //     const result = await basicCodeIntel.definition(textDocument, position)
+                        //     if (result) {
+                        //         if (Array.isArray(result)) {
+                        //             yield result.map(v => ({ ...v, badge: impreciseBadge }))
+                        //         } else {
+                        //             yield { ...result, badge: impreciseBadge }
+                        //         }
+                        //     } else {
+                        //         yield undefined
+                        //     }
+                    } else {
+                        const textDocumentUri = new URL(textDocument.uri)
+                        const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                        const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                        const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                        // Poll server to get updated contents when e.g. dependency installation finished
+                        while (true) {
+                            const definitionResult = (await sendTracedRequest(
+                                connection,
+                                DefinitionRequest.type,
+                                {
+                                    textDocument: { uri: serverTextDocumentUri.href },
+                                    position,
+                                },
+                                { span, tracer, token }
+                            )) as Location[] | Location | null
+                            rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
+                            yield convertLocations(definitionResult)
+                            await delayPromise(HOVER_DEF_POLL_INTERVAL)
+                        }
                     }
-                    // }
                 })
         )
         // providers.add(
@@ -612,196 +612,199 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('References trace', span.generateTraceURL())
                 }
 
-                // if (!config.value['typescript.serverUrl']) {
-                //     // Gets an opaque value that is the same for all locations
-                //     // within a file but different from other files.
-                //     const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
+                if (false) {
+                    //     // Gets an opaque value that is the same for all locations
+                    //     // within a file but different from other files.
+                    //     const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
+                    //     const lsifReferences = await lsif.references(textDocument, position)
+                    //     const fuzzyReferences = (await basicCodeIntel.references(textDocument, position)) || []
+                    //     const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
+                    //     yield [
+                    //         ...(lsifReferences === undefined ? [] : lsifReferences.value),
+                    //         ...fuzzyReferences
+                    //             .filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef)))
+                    //             .map(v => ({ ...v, badge: impreciseBadge })),
+                    //     ]
+                } else {
+                    const textDocumentUri = new URL(textDocument.uri)
+                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                //     const lsifReferences = await lsif.references(textDocument, position)
-                //     const fuzzyReferences = (await basicCodeIntel.references(textDocument, position)) || []
+                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
 
-                //     const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
-
-                //     yield [
-                //         ...(lsifReferences === undefined ? [] : lsifReferences.value),
-                //         ...fuzzyReferences
-                //             .filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef)))
-                //             .map(v => ({ ...v, badge: impreciseBadge })),
-                //     ]
-                // } else {
-                const textDocumentUri = new URL(textDocument.uri)
-                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
-
-                const connection = await getOrCreateConnection(serverRootUri, { span, token })
-
-                const findLocalReferences = () =>
-                    traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
-                        logger.log('Searching for same-repo references')
-                        const localReferences = asArray(
-                            await sendTracedRequest(
-                                connection,
-                                ReferencesRequest.type,
-                                {
-                                    textDocument: { uri: serverTextDocumentUri.href },
-                                    position,
-                                    context,
-                                },
-                                { span, tracer, token }
-                            )
-                        )
-                        logger.log(`Found ${localReferences.length} same-repo references`)
-                        yield localReferences
-                    })
-
-                const findExternalReferences = () =>
-                    traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
-                        try {
-                            logger.log('Getting canonical definition for cross-repo references')
-                            const definition: Location | undefined = asArray((await sendTracedRequest(
-                                connection,
-                                DefinitionRequest.type,
-                                {
-                                    textDocument: { uri: serverTextDocumentUri.href },
-                                    position,
-                                },
-                                { span, tracer, token }
-                            )) as Location[] | Location | null)[0]
-                            if (!definition) {
-                                return
-                            }
-                            span.setTag('uri', redact(definition.uri))
-                            span.setTag('line', definition.range.start.line)
-
-                            const findPackageDependents =
-                                clientSgEndpoint.url.hostname === 'sourcegraph.com'
-                                    ? findPackageDependentsWithNpm
-                                    : findPackageDependentsWithSourcegraphSearch
-
-                            logger.log(`Getting external references for definition`, definition)
-
-                            const definitionUri = new URL(definition.uri)
-
-                            const referenceParams: ReferenceParams = {
-                                textDocument: { uri: definitionUri.href },
-                                position: definition.range.start,
-                                context: { includeDeclaration: false },
-                            }
-
-                            // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
-                            const clientDefinitionUrl = new URL(definitionUri.href)
-                            clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
-                            clientDefinitionUrl.host = clientSgEndpoint.url.host
-                            const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
-
-                            // Find dependent packages on the package
-                            const dependents =
-                                packageName === 'sourcegraph'
-                                    ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
-                                      // Extensions are not published to npm, so search the extension registry
-                                      findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
-                                          logger,
-                                          tracer,
-                                          span,
-                                      })
-                                    : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
-
-                            // Search for references in each dependent
-                            const findExternalRefsInDependent = (repoName: string) =>
-                                traceAsyncGenerator(
-                                    'Find external references in dependent',
-                                    tracer,
-                                    span,
-                                    async function*(span) {
-                                        try {
-                                            logger.log(`Looking for external references in dependent repo ${repoName}`)
-                                            span.setTag('repoName', repoName)
-                                            const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
-                                                span,
-                                                tracer,
-                                            })
-                                            const rootUri = new URL(
-                                                `${repoName}@${commitID}/-/raw/`,
-                                                serverSgEndpoint.url
-                                            )
-                                            if (serverSgEndpoint.accessToken) {
-                                                rootUri.username = serverSgEndpoint.accessToken
-                                            }
-
-                                            yield await withTempConnection(
-                                                rootUri,
-                                                { span, token },
-                                                async connection => {
-                                                    const references = asArray(
-                                                        await sendTracedRequest(
-                                                            connection,
-                                                            ReferencesRequest.type,
-                                                            referenceParams,
-                                                            {
-                                                                span,
-                                                                tracer,
-                                                                token,
-                                                            }
-                                                        )
-                                                    )
-                                                    logger.log(
-                                                        `Found ${references.length} references in dependent repo ${repoName}`
-                                                    )
-                                                    // Only include references in the external repo, do not duplicate references in the same repo
-                                                    return references.filter(location =>
-                                                        location.uri.startsWith(rootUri.href)
-                                                    )
-                                                }
-                                            )
-                                        } catch (err) {
-                                            throwIfAbortError(err)
-                                            logErrorEvent(span, err)
-                                            logger.error(
-                                                `Error searching dependent repo ${repoName} for references`,
-                                                err
-                                            )
-                                        }
-                                    }
+                    const findLocalReferences = () =>
+                        traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
+                            logger.log('Searching for same-repo references')
+                            const localReferences = asArray(
+                                await sendTracedRequest(
+                                    connection,
+                                    ReferencesRequest.type,
+                                    {
+                                        textDocument: { uri: serverTextDocumentUri.href },
+                                        position,
+                                        context,
+                                    },
+                                    { span, tracer, token }
                                 )
-                            yield* flatMapConcurrent(dependents, EXTERNAL_REFS_CONCURRENCY, findExternalRefsInDependent)
-                            logger.log('Done going through dependents')
-                        } catch (err) {
-                            logger.error('Could not find external references', err)
-                        }
-                    })
+                            )
+                            logger.log(`Found ${localReferences.length} same-repo references`)
+                            yield localReferences
+                        })
 
-                yield* merge(findLocalReferences(), findExternalReferences()).pipe(
-                    // Same-repo references
-                    // Cross-repo references
-                    // Find canonical source location
-                    filter(chunk => chunk.length > 0),
-                    tap({
-                        next: chunk => {
-                            span.log({ event: 'chunk', count: chunk.length })
-                        },
-                    }),
-                    // Rewrite URIs and convert from LSP to Sourcegraph Location
-                    map(chunk =>
-                        chunk
-                            .map(location => {
-                                try {
-                                    return convertLocation({
-                                        ...location,
-                                        uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
-                                    })
-                                } catch (err) {
-                                    return undefined
+                    const findExternalReferences = () =>
+                        traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
+                            try {
+                                logger.log('Getting canonical definition for cross-repo references')
+                                const definition: Location | undefined = asArray((await sendTracedRequest(
+                                    connection,
+                                    DefinitionRequest.type,
+                                    {
+                                        textDocument: { uri: serverTextDocumentUri.href },
+                                        position,
+                                    },
+                                    { span, tracer, token }
+                                )) as Location[] | Location | null)[0]
+                                if (!definition) {
+                                    return
                                 }
-                            })
-                            .filter((location): location is Exclude<typeof location, undefined> => !!location)
-                    ),
-                    // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
-                    scan<sourcegraph.Location[], sourcegraph.Location[]>(
-                        (allReferences, chunk) => allReferences.concat(chunk),
-                        []
+                                span.setTag('uri', redact(definition.uri))
+                                span.setTag('line', definition.range.start.line)
+
+                                const findPackageDependents =
+                                    clientSgEndpoint.url.hostname === 'sourcegraph.com'
+                                        ? findPackageDependentsWithNpm
+                                        : findPackageDependentsWithSourcegraphSearch
+
+                                logger.log(`Getting external references for definition`, definition)
+
+                                const definitionUri = new URL(definition.uri)
+
+                                const referenceParams: ReferenceParams = {
+                                    textDocument: { uri: definitionUri.href },
+                                    position: definition.range.start,
+                                    context: { includeDeclaration: false },
+                                }
+
+                                // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
+                                const clientDefinitionUrl = new URL(definitionUri.href)
+                                clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
+                                clientDefinitionUrl.host = clientSgEndpoint.url.host
+                                const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
+
+                                // Find dependent packages on the package
+                                const dependents =
+                                    packageName === 'sourcegraph'
+                                        ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
+                                          // Extensions are not published to npm, so search the extension registry
+                                          findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
+                                              logger,
+                                              tracer,
+                                              span,
+                                          })
+                                        : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
+
+                                // Search for references in each dependent
+                                const findExternalRefsInDependent = (repoName: string) =>
+                                    traceAsyncGenerator(
+                                        'Find external references in dependent',
+                                        tracer,
+                                        span,
+                                        async function*(span) {
+                                            try {
+                                                logger.log(
+                                                    `Looking for external references in dependent repo ${repoName}`
+                                                )
+                                                span.setTag('repoName', repoName)
+                                                const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
+                                                    span,
+                                                    tracer,
+                                                })
+                                                const rootUri = new URL(
+                                                    `${repoName}@${commitID}/-/raw/`,
+                                                    serverSgEndpoint.url
+                                                )
+                                                if (serverSgEndpoint.accessToken) {
+                                                    rootUri.username = serverSgEndpoint.accessToken
+                                                }
+
+                                                yield await withTempConnection(
+                                                    rootUri,
+                                                    { span, token },
+                                                    async connection => {
+                                                        const references = asArray(
+                                                            await sendTracedRequest(
+                                                                connection,
+                                                                ReferencesRequest.type,
+                                                                referenceParams,
+                                                                {
+                                                                    span,
+                                                                    tracer,
+                                                                    token,
+                                                                }
+                                                            )
+                                                        )
+                                                        logger.log(
+                                                            `Found ${references.length} references in dependent repo ${repoName}`
+                                                        )
+                                                        // Only include references in the external repo, do not duplicate references in the same repo
+                                                        return references.filter(location =>
+                                                            location.uri.startsWith(rootUri.href)
+                                                        )
+                                                    }
+                                                )
+                                            } catch (err) {
+                                                throwIfAbortError(err)
+                                                logErrorEvent(span, err)
+                                                logger.error(
+                                                    `Error searching dependent repo ${repoName} for references`,
+                                                    err
+                                                )
+                                            }
+                                        }
+                                    )
+                                yield* flatMapConcurrent(
+                                    dependents,
+                                    EXTERNAL_REFS_CONCURRENCY,
+                                    findExternalRefsInDependent
+                                )
+                                logger.log('Done going through dependents')
+                            } catch (err) {
+                                logger.error('Could not find external references', err)
+                            }
+                        })
+
+                    yield* merge(findLocalReferences(), findExternalReferences()).pipe(
+                        // Same-repo references
+                        // Cross-repo references
+                        // Find canonical source location
+                        filter(chunk => chunk.length > 0),
+                        tap({
+                            next: chunk => {
+                                span.log({ event: 'chunk', count: chunk.length })
+                            },
+                        }),
+                        // Rewrite URIs and convert from LSP to Sourcegraph Location
+                        map(chunk =>
+                            chunk
+                                .map(location => {
+                                    try {
+                                        return convertLocation({
+                                            ...location,
+                                            uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
+                                        })
+                                    } catch (err) {
+                                        return undefined
+                                    }
+                                })
+                                .filter((location): location is Exclude<typeof location, undefined> => !!location)
+                        ),
+                        // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
+                        scan<sourcegraph.Location[], sourcegraph.Location[]>(
+                            (allReferences, chunk) => allReferences.concat(chunk),
+                            []
+                        )
                     )
-                )
-                // }
+                }
             })
         // providers.add(
         //     sourcegraph.languages.registerReferenceProvider(documentSelector, {

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -6,7 +6,7 @@ import { URL as _URL, URLSearchParams as _URLSearchParams } from 'whatwg-url'
 Object.assign(_URL, self.URL)
 Object.assign(self, { URL: _URL, URLSearchParams: _URLSearchParams })
 
-import { initLSIF, impreciseBadge } from '@sourcegraph/basic-code-intel'
+import { activateCodeIntel } from '@sourcegraph/basic-code-intel'
 import { Tracer as LightstepTracer } from '@sourcegraph/lightstep-tracer-webworker'
 import {
     createMessageConnection,
@@ -57,7 +57,7 @@ import {
     tracePromise,
 } from '../common/tracing'
 import { getOrCreateAccessToken } from './auth'
-import { initBasicCodeIntel } from './basic-code-intel'
+import { handlerArgs } from './basic-code-intel'
 import {
     findPackageDependentsWithNpm,
     findPackageDependentsWithSourcegraphExtensionRegistry as findDependentsWithSourcegraphExtensionRegistry,
@@ -84,14 +84,7 @@ import {
     toServerTextDocumentUri,
     toSourcegraphTextDocumentUri,
 } from './uris'
-import {
-    abortPrevious,
-    areProviderParamsEqual,
-    asArray,
-    distinctUntilChanged,
-    observableFromAsyncGenerator,
-    SourcegraphEndpoint,
-} from './util'
+import { abortPrevious, asArray, SourcegraphEndpoint } from './util'
 
 const HOVER_DEF_POLL_INTERVAL = 2000
 const EXTERNAL_REFS_CONCURRENCY = 7
@@ -119,9 +112,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
 
     const config = new BehaviorSubject(getConfig())
     ctx.subscriptions.add(sourcegraph.configuration.subscribe(() => config.next(getConfig())))
-
-    const lsif = initLSIF()
-    const basicCodeIntel = initBasicCodeIntel()
 
     const tracer: Tracer = config.value['lightstep.token']
         ? new LightstepTracer({ access_token: config.value['lightstep.token'], component_name: 'ext-lang-typescript' })
@@ -512,49 +502,49 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('Hover trace', span.generateTraceURL())
                 }
 
-                const lsifResult = await lsif.hover(textDocument, position)
-                if (lsifResult) {
-                    yield lsifResult.value
-                } else if (!config.value['typescript.serverUrl']) {
-                    const result = await basicCodeIntel.hover(textDocument, position)
-                    if (result) {
-                        yield { ...result, badge: impreciseBadge }
-                    } else {
-                        yield undefined
-                    }
-                } else {
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                // const lsifResult = await lsif.hover(textDocument, position)
+                // if (lsifResult) {
+                //     yield lsifResult.value
+                // } else if (!config.value['typescript.serverUrl']) {
+                //     const result = await basicCodeIntel.hover(textDocument, position)
+                //     if (result) {
+                //         yield { ...result, badge: impreciseBadge }
+                //     } else {
+                //         yield undefined
+                //     }
+                // } else {
+                const textDocumentUri = new URL(textDocument.uri)
+                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                    // Poll server to get updated results when e.g. dependency installation finished
-                    while (true) {
-                        const hoverResult = await sendTracedRequest(
-                            connection,
-                            HoverRequest.type,
-                            {
-                                textDocument: { uri: serverTextDocumentUri.href },
-                                position,
-                            },
-                            { span, tracer, token }
-                        )
-                        rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
-                        yield convertHover(hoverResult)
-                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
-                    }
-                }
-            })
-        )
-        providers.add(
-            sourcegraph.languages.registerHoverProvider(documentSelector, {
-                provideHover: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-                    observableFromAsyncGenerator(provideHover.bind(null, textDocument, position)).pipe(
-                        rxop.shareReplay(1)
+                const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                // Poll server to get updated results when e.g. dependency installation finished
+                while (true) {
+                    const hoverResult = await sendTracedRequest(
+                        connection,
+                        HoverRequest.type,
+                        {
+                            textDocument: { uri: serverTextDocumentUri.href },
+                            position,
+                        },
+                        { span, tracer, token }
                     )
-                ),
+                    rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
+                    yield convertHover(hoverResult)
+                    await delayPromise(HOVER_DEF_POLL_INTERVAL)
+                }
+                // }
             })
         )
+        // providers.add(
+        //     sourcegraph.languages.registerHoverProvider(documentSelector, {
+        //         provideHover: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
+        //             observableFromAsyncGenerator(provideHover.bind(null, textDocument, position)).pipe(
+        //                 rxop.shareReplay(1)
+        //             )
+        //         ),
+        //     })
+        // )
 
         // Definition
         const provideDefinition = abortPrevious(
@@ -564,52 +554,52 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         logger.log('Definition trace', span.generateTraceURL())
                     }
 
-                    const lsifResult = await lsif.definition(textDocument, position)
-                    if (lsifResult) {
-                        yield lsifResult.value
-                    } else if (!config.value['typescript.serverUrl']) {
-                        const result = await basicCodeIntel.definition(textDocument, position)
-                        if (result) {
-                            if (Array.isArray(result)) {
-                                yield result.map(v => ({ ...v, badge: impreciseBadge }))
-                            } else {
-                                yield { ...result, badge: impreciseBadge }
-                            }
-                        } else {
-                            yield undefined
-                        }
-                    } else {
-                        const textDocumentUri = new URL(textDocument.uri)
-                        const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                        const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
-                        const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                        // Poll server to get updated contents when e.g. dependency installation finished
-                        while (true) {
-                            const definitionResult = (await sendTracedRequest(
-                                connection,
-                                DefinitionRequest.type,
-                                {
-                                    textDocument: { uri: serverTextDocumentUri.href },
-                                    position,
-                                },
-                                { span, tracer, token }
-                            )) as Location[] | Location | null
-                            rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
-                            yield convertLocations(definitionResult)
-                            await delayPromise(HOVER_DEF_POLL_INTERVAL)
-                        }
+                    // const lsifResult = await lsif.definition(textDocument, position)
+                    // if (lsifResult) {
+                    //     yield lsifResult.value
+                    // } else if (!config.value['typescript.serverUrl']) {
+                    //     const result = await basicCodeIntel.definition(textDocument, position)
+                    //     if (result) {
+                    //         if (Array.isArray(result)) {
+                    //             yield result.map(v => ({ ...v, badge: impreciseBadge }))
+                    //         } else {
+                    //             yield { ...result, badge: impreciseBadge }
+                    //         }
+                    //     } else {
+                    //         yield undefined
+                    //     }
+                    // } else {
+                    const textDocumentUri = new URL(textDocument.uri)
+                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                    // Poll server to get updated contents when e.g. dependency installation finished
+                    while (true) {
+                        const definitionResult = (await sendTracedRequest(
+                            connection,
+                            DefinitionRequest.type,
+                            {
+                                textDocument: { uri: serverTextDocumentUri.href },
+                                position,
+                            },
+                            { span, tracer, token }
+                        )) as Location[] | Location | null
+                        rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
+                        yield convertLocations(definitionResult)
+                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
                     }
+                    // }
                 })
         )
-        providers.add(
-            sourcegraph.languages.registerDefinitionProvider(documentSelector, {
-                provideDefinition: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-                    observableFromAsyncGenerator(provideDefinition.bind(null, textDocument, position)).pipe(
-                        rxop.shareReplay(1)
-                    )
-                ),
-            })
-        )
+        // providers.add(
+        //     sourcegraph.languages.registerDefinitionProvider(documentSelector, {
+        //         provideDefinition: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
+        //             observableFromAsyncGenerator(provideDefinition.bind(null, textDocument, position)).pipe(
+        //                 rxop.shareReplay(1)
+        //             )
+        //         ),
+        //     })
+        // )
 
         // References
         const provideReferences = (
@@ -622,250 +612,255 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('References trace', span.generateTraceURL())
                 }
 
-                if (!config.value['typescript.serverUrl']) {
-                    // Gets an opaque value that is the same for all locations
-                    // within a file but different from other files.
-                    const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
+                // if (!config.value['typescript.serverUrl']) {
+                //     // Gets an opaque value that is the same for all locations
+                //     // within a file but different from other files.
+                //     const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
 
-                    const lsifReferences = await lsif.references(textDocument, position)
-                    const fuzzyReferences = (await basicCodeIntel.references(textDocument, position)) || []
+                //     const lsifReferences = await lsif.references(textDocument, position)
+                //     const fuzzyReferences = (await basicCodeIntel.references(textDocument, position)) || []
 
-                    const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
+                //     const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
 
-                    yield [
-                        ...(lsifReferences === undefined ? [] : lsifReferences.value),
-                        ...fuzzyReferences
-                            .filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef)))
-                            .map(v => ({ ...v, badge: impreciseBadge })),
-                    ]
-                } else {
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                //     yield [
+                //         ...(lsifReferences === undefined ? [] : lsifReferences.value),
+                //         ...fuzzyReferences
+                //             .filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef)))
+                //             .map(v => ({ ...v, badge: impreciseBadge })),
+                //     ]
+                // } else {
+                const textDocumentUri = new URL(textDocument.uri)
+                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                const connection = await getOrCreateConnection(serverRootUri, { span, token })
 
-                    const findLocalReferences = () =>
-                        traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
-                            logger.log('Searching for same-repo references')
-                            const localReferences = asArray(
-                                await sendTracedRequest(
-                                    connection,
-                                    ReferencesRequest.type,
-                                    {
-                                        textDocument: { uri: serverTextDocumentUri.href },
-                                        position,
-                                        context,
-                                    },
-                                    { span, tracer, token }
-                                )
+                const findLocalReferences = () =>
+                    traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
+                        logger.log('Searching for same-repo references')
+                        const localReferences = asArray(
+                            await sendTracedRequest(
+                                connection,
+                                ReferencesRequest.type,
+                                {
+                                    textDocument: { uri: serverTextDocumentUri.href },
+                                    position,
+                                    context,
+                                },
+                                { span, tracer, token }
                             )
-                            logger.log(`Found ${localReferences.length} same-repo references`)
-                            yield localReferences
-                        })
-
-                    const findExternalReferences = () =>
-                        traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
-                            try {
-                                logger.log('Getting canonical definition for cross-repo references')
-                                const definition: Location | undefined = asArray((await sendTracedRequest(
-                                    connection,
-                                    DefinitionRequest.type,
-                                    {
-                                        textDocument: { uri: serverTextDocumentUri.href },
-                                        position,
-                                    },
-                                    { span, tracer, token }
-                                )) as Location[] | Location | null)[0]
-                                if (!definition) {
-                                    return
-                                }
-                                span.setTag('uri', redact(definition.uri))
-                                span.setTag('line', definition.range.start.line)
-
-                                const findPackageDependents =
-                                    clientSgEndpoint.url.hostname === 'sourcegraph.com'
-                                        ? findPackageDependentsWithNpm
-                                        : findPackageDependentsWithSourcegraphSearch
-
-                                logger.log(`Getting external references for definition`, definition)
-
-                                const definitionUri = new URL(definition.uri)
-
-                                const referenceParams: ReferenceParams = {
-                                    textDocument: { uri: definitionUri.href },
-                                    position: definition.range.start,
-                                    context: { includeDeclaration: false },
-                                }
-
-                                // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
-                                const clientDefinitionUrl = new URL(definitionUri.href)
-                                clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
-                                clientDefinitionUrl.host = clientSgEndpoint.url.host
-                                const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
-
-                                // Find dependent packages on the package
-                                const dependents =
-                                    packageName === 'sourcegraph'
-                                        ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
-                                          // Extensions are not published to npm, so search the extension registry
-                                          findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
-                                              logger,
-                                              tracer,
-                                              span,
-                                          })
-                                        : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
-
-                                // Search for references in each dependent
-                                const findExternalRefsInDependent = (repoName: string) =>
-                                    traceAsyncGenerator(
-                                        'Find external references in dependent',
-                                        tracer,
-                                        span,
-                                        async function*(span) {
-                                            try {
-                                                logger.log(
-                                                    `Looking for external references in dependent repo ${repoName}`
-                                                )
-                                                span.setTag('repoName', repoName)
-                                                const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
-                                                    span,
-                                                    tracer,
-                                                })
-                                                const rootUri = new URL(
-                                                    `${repoName}@${commitID}/-/raw/`,
-                                                    serverSgEndpoint.url
-                                                )
-                                                if (serverSgEndpoint.accessToken) {
-                                                    rootUri.username = serverSgEndpoint.accessToken
-                                                }
-
-                                                yield await withTempConnection(
-                                                    rootUri,
-                                                    { span, token },
-                                                    async connection => {
-                                                        const references = asArray(
-                                                            await sendTracedRequest(
-                                                                connection,
-                                                                ReferencesRequest.type,
-                                                                referenceParams,
-                                                                {
-                                                                    span,
-                                                                    tracer,
-                                                                    token,
-                                                                }
-                                                            )
-                                                        )
-                                                        logger.log(
-                                                            `Found ${references.length} references in dependent repo ${repoName}`
-                                                        )
-                                                        // Only include references in the external repo, do not duplicate references in the same repo
-                                                        return references.filter(location =>
-                                                            location.uri.startsWith(rootUri.href)
-                                                        )
-                                                    }
-                                                )
-                                            } catch (err) {
-                                                throwIfAbortError(err)
-                                                logErrorEvent(span, err)
-                                                logger.error(
-                                                    `Error searching dependent repo ${repoName} for references`,
-                                                    err
-                                                )
-                                            }
-                                        }
-                                    )
-                                yield* flatMapConcurrent(
-                                    dependents,
-                                    EXTERNAL_REFS_CONCURRENCY,
-                                    findExternalRefsInDependent
-                                )
-                                logger.log('Done going through dependents')
-                            } catch (err) {
-                                logger.error('Could not find external references', err)
-                            }
-                        })
-
-                    yield* merge(findLocalReferences(), findExternalReferences()).pipe(
-                        // Same-repo references
-                        // Cross-repo references
-                        // Find canonical source location
-                        filter(chunk => chunk.length > 0),
-                        tap({
-                            next: chunk => {
-                                span.log({ event: 'chunk', count: chunk.length })
-                            },
-                        }),
-                        // Rewrite URIs and convert from LSP to Sourcegraph Location
-                        map(chunk =>
-                            chunk
-                                .map(location => {
-                                    try {
-                                        return convertLocation({
-                                            ...location,
-                                            uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
-                                        })
-                                    } catch (err) {
-                                        return undefined
-                                    }
-                                })
-                                .filter((location): location is Exclude<typeof location, undefined> => !!location)
-                        ),
-                        // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
-                        scan<sourcegraph.Location[], sourcegraph.Location[]>(
-                            (allReferences, chunk) => allReferences.concat(chunk),
-                            []
                         )
+                        logger.log(`Found ${localReferences.length} same-repo references`)
+                        yield localReferences
+                    })
+
+                const findExternalReferences = () =>
+                    traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
+                        try {
+                            logger.log('Getting canonical definition for cross-repo references')
+                            const definition: Location | undefined = asArray((await sendTracedRequest(
+                                connection,
+                                DefinitionRequest.type,
+                                {
+                                    textDocument: { uri: serverTextDocumentUri.href },
+                                    position,
+                                },
+                                { span, tracer, token }
+                            )) as Location[] | Location | null)[0]
+                            if (!definition) {
+                                return
+                            }
+                            span.setTag('uri', redact(definition.uri))
+                            span.setTag('line', definition.range.start.line)
+
+                            const findPackageDependents =
+                                clientSgEndpoint.url.hostname === 'sourcegraph.com'
+                                    ? findPackageDependentsWithNpm
+                                    : findPackageDependentsWithSourcegraphSearch
+
+                            logger.log(`Getting external references for definition`, definition)
+
+                            const definitionUri = new URL(definition.uri)
+
+                            const referenceParams: ReferenceParams = {
+                                textDocument: { uri: definitionUri.href },
+                                position: definition.range.start,
+                                context: { includeDeclaration: false },
+                            }
+
+                            // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
+                            const clientDefinitionUrl = new URL(definitionUri.href)
+                            clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
+                            clientDefinitionUrl.host = clientSgEndpoint.url.host
+                            const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
+
+                            // Find dependent packages on the package
+                            const dependents =
+                                packageName === 'sourcegraph'
+                                    ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
+                                      // Extensions are not published to npm, so search the extension registry
+                                      findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
+                                          logger,
+                                          tracer,
+                                          span,
+                                      })
+                                    : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
+
+                            // Search for references in each dependent
+                            const findExternalRefsInDependent = (repoName: string) =>
+                                traceAsyncGenerator(
+                                    'Find external references in dependent',
+                                    tracer,
+                                    span,
+                                    async function*(span) {
+                                        try {
+                                            logger.log(`Looking for external references in dependent repo ${repoName}`)
+                                            span.setTag('repoName', repoName)
+                                            const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
+                                                span,
+                                                tracer,
+                                            })
+                                            const rootUri = new URL(
+                                                `${repoName}@${commitID}/-/raw/`,
+                                                serverSgEndpoint.url
+                                            )
+                                            if (serverSgEndpoint.accessToken) {
+                                                rootUri.username = serverSgEndpoint.accessToken
+                                            }
+
+                                            yield await withTempConnection(
+                                                rootUri,
+                                                { span, token },
+                                                async connection => {
+                                                    const references = asArray(
+                                                        await sendTracedRequest(
+                                                            connection,
+                                                            ReferencesRequest.type,
+                                                            referenceParams,
+                                                            {
+                                                                span,
+                                                                tracer,
+                                                                token,
+                                                            }
+                                                        )
+                                                    )
+                                                    logger.log(
+                                                        `Found ${references.length} references in dependent repo ${repoName}`
+                                                    )
+                                                    // Only include references in the external repo, do not duplicate references in the same repo
+                                                    return references.filter(location =>
+                                                        location.uri.startsWith(rootUri.href)
+                                                    )
+                                                }
+                                            )
+                                        } catch (err) {
+                                            throwIfAbortError(err)
+                                            logErrorEvent(span, err)
+                                            logger.error(
+                                                `Error searching dependent repo ${repoName} for references`,
+                                                err
+                                            )
+                                        }
+                                    }
+                                )
+                            yield* flatMapConcurrent(dependents, EXTERNAL_REFS_CONCURRENCY, findExternalRefsInDependent)
+                            logger.log('Done going through dependents')
+                        } catch (err) {
+                            logger.error('Could not find external references', err)
+                        }
+                    })
+
+                yield* merge(findLocalReferences(), findExternalReferences()).pipe(
+                    // Same-repo references
+                    // Cross-repo references
+                    // Find canonical source location
+                    filter(chunk => chunk.length > 0),
+                    tap({
+                        next: chunk => {
+                            span.log({ event: 'chunk', count: chunk.length })
+                        },
+                    }),
+                    // Rewrite URIs and convert from LSP to Sourcegraph Location
+                    map(chunk =>
+                        chunk
+                            .map(location => {
+                                try {
+                                    return convertLocation({
+                                        ...location,
+                                        uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
+                                    })
+                                } catch (err) {
+                                    return undefined
+                                }
+                            })
+                            .filter((location): location is Exclude<typeof location, undefined> => !!location)
+                    ),
+                    // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
+                    scan<sourcegraph.Location[], sourcegraph.Location[]>(
+                        (allReferences, chunk) => allReferences.concat(chunk),
+                        []
                     )
+                )
+                // }
+            })
+        // providers.add(
+        //     sourcegraph.languages.registerReferenceProvider(documentSelector, {
+        //         provideReferences: (doc, pos, ctx) =>
+        //             observableFromAsyncGenerator(provideReferences.bind(null, doc, pos, ctx)),
+        //     })
+        // )
+
+        // if (config.value['typescript.serverUrl']) {
+        // Implementations
+        // const IMPL_ID = 'ts.impl' // implementations panel and provider ID
+        const provideImpls = (
+            textDocument: sourcegraph.TextDocument,
+            position: sourcegraph.Position
+        ): AsyncGenerator<sourcegraph.Location[] | null> =>
+            traceAsyncGenerator('Provide implementations', tracer, undefined, async function*(span) {
+                if (canGenerateTraceUrl(span)) {
+                    logger.log('Implementation trace', span.generateTraceURL())
                 }
-            })
-        providers.add(
-            sourcegraph.languages.registerReferenceProvider(documentSelector, {
-                provideReferences: (doc, pos, ctx) =>
-                    observableFromAsyncGenerator(provideReferences.bind(null, doc, pos, ctx)),
-            })
-        )
 
-        if (config.value['typescript.serverUrl']) {
-            // Implementations
-            const IMPL_ID = 'ts.impl' // implementations panel and provider ID
-            const provideImpls = (
-                textDocument: sourcegraph.TextDocument,
-                position: sourcegraph.Position
-            ): Promise<sourcegraph.Location[] | null> =>
-                tracePromise('Provide implementations', tracer, undefined, async span => {
-                    if (canGenerateTraceUrl(span)) {
-                        logger.log('Implementation trace', span.generateTraceURL())
-                    }
+                const textDocumentUri = new URL(textDocument.uri)
+                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                const implementationParams: TextDocumentPositionParams = {
+                    textDocument: { uri: serverTextDocumentUri.href },
+                    position,
+                }
+                const implementationResult = (await sendTracedRequest(
+                    connection,
+                    ImplementationRequest.type,
+                    implementationParams,
+                    { span, tracer, token }
+                )) as Location[] | Location | null
+                rewriteUris(implementationResult, toSourcegraphTextDocumentUri)
+                yield convertLocations(implementationResult)
+            })
+        // providers.add(
+        //     sourcegraph.languages.registerLocationProvider(IMPL_ID, documentSelector, {
+        //         provideLocations: provideImpls,
+        //     })
+        // )
+        // const panelView = sourcegraph.app.createPanelView(IMPL_ID)
+        // panelView.title = 'Implementations'
+        // panelView.component = { locationProvider: IMPL_ID }
+        // panelView.priority = 160
+        // providers.add(panelView)
+        // }
 
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                    const implementationParams: TextDocumentPositionParams = {
-                        textDocument: { uri: serverTextDocumentUri.href },
-                        position,
-                    }
-                    const implementationResult = (await sendTracedRequest(
-                        connection,
-                        ImplementationRequest.type,
-                        implementationParams,
-                        { span, tracer, token }
-                    )) as Location[] | Location | null
-                    rewriteUris(implementationResult, toSourcegraphTextDocumentUri)
-                    return convertLocations(implementationResult)
-                })
-            providers.add(
-                sourcegraph.languages.registerLocationProvider(IMPL_ID, documentSelector, {
-                    provideLocations: provideImpls,
-                })
-            )
-            const panelView = sourcegraph.app.createPanelView(IMPL_ID)
-            panelView.title = 'Implementations'
-            panelView.component = { locationProvider: IMPL_ID }
-            panelView.priority = 160
-            providers.add(panelView)
-        }
+        activateCodeIntel(ctx, documentSelector, handlerArgs, {
+            definition: provideDefinition,
+            references: provideReferences,
+            hover: provideHover,
+            implementations: {
+                implId: 'ts.impl',
+                panelTitle: 'Implementations',
+                locations: provideImpls,
+            },
+        })
     }
 }
 

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -502,49 +502,28 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('Hover trace', span.generateTraceURL())
                 }
 
-                // const lsifResult = await lsif.hover(textDocument, position)
-                if (false) {
-                    //     yield lsifResult.value
-                    // } else if (!config.value['typescript.serverUrl']) {
-                    //     const result = await basicCodeIntel.hover(textDocument, position)
-                    //     if (result) {
-                    //         yield { ...result, badge: impreciseBadge }
-                    //     } else {
-                    //         yield undefined
-                    //     }
-                } else {
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                const textDocumentUri = new URL(textDocument.uri)
+                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                    // Poll server to get updated results when e.g. dependency installation finished
-                    while (true) {
-                        const hoverResult = await sendTracedRequest(
-                            connection,
-                            HoverRequest.type,
-                            {
-                                textDocument: { uri: serverTextDocumentUri.href },
-                                position,
-                            },
-                            { span, tracer, token }
-                        )
-                        rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
-                        yield convertHover(hoverResult)
-                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
-                    }
+                const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                // Poll server to get updated results when e.g. dependency installation finished
+                while (true) {
+                    const hoverResult = await sendTracedRequest(
+                        connection,
+                        HoverRequest.type,
+                        {
+                            textDocument: { uri: serverTextDocumentUri.href },
+                            position,
+                        },
+                        { span, tracer, token }
+                    )
+                    rewriteUris(hoverResult, toSourcegraphTextDocumentUri)
+                    yield convertHover(hoverResult)
+                    await delayPromise(HOVER_DEF_POLL_INTERVAL)
                 }
             })
         )
-        // providers.add(
-        //     sourcegraph.languages.registerHoverProvider(documentSelector, {
-        //         provideHover: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-        //             observableFromAsyncGenerator(provideHover.bind(null, textDocument, position)).pipe(
-        //                 rxop.shareReplay(1)
-        //             )
-        //         ),
-        //     })
-        // )
 
         // Definition
         const provideDefinition = abortPrevious(
@@ -554,52 +533,27 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                         logger.log('Definition trace', span.generateTraceURL())
                     }
 
-                    // const lsifResult = await lsif.definition(textDocument, position)
-                    if (false) {
-                        //     yield lsifResult.value
-                        // } else if (!config.value['typescript.serverUrl']) {
-                        //     const result = await basicCodeIntel.definition(textDocument, position)
-                        //     if (result) {
-                        //         if (Array.isArray(result)) {
-                        //             yield result.map(v => ({ ...v, badge: impreciseBadge }))
-                        //         } else {
-                        //             yield { ...result, badge: impreciseBadge }
-                        //         }
-                        //     } else {
-                        //         yield undefined
-                        //     }
-                    } else {
-                        const textDocumentUri = new URL(textDocument.uri)
-                        const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                        const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
-                        const connection = await getOrCreateConnection(serverRootUri, { span, token })
-                        // Poll server to get updated contents when e.g. dependency installation finished
-                        while (true) {
-                            const definitionResult = (await sendTracedRequest(
-                                connection,
-                                DefinitionRequest.type,
-                                {
-                                    textDocument: { uri: serverTextDocumentUri.href },
-                                    position,
-                                },
-                                { span, tracer, token }
-                            )) as Location[] | Location | null
-                            rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
-                            yield convertLocations(definitionResult)
-                            await delayPromise(HOVER_DEF_POLL_INTERVAL)
-                        }
+                    const textDocumentUri = new URL(textDocument.uri)
+                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                    // Poll server to get updated contents when e.g. dependency installation finished
+                    while (true) {
+                        const definitionResult = (await sendTracedRequest(
+                            connection,
+                            DefinitionRequest.type,
+                            {
+                                textDocument: { uri: serverTextDocumentUri.href },
+                                position,
+                            },
+                            { span, tracer, token }
+                        )) as Location[] | Location | null
+                        rewriteUris(definitionResult, toSourcegraphTextDocumentUri)
+                        yield convertLocations(definitionResult)
+                        await delayPromise(HOVER_DEF_POLL_INTERVAL)
                     }
                 })
         )
-        // providers.add(
-        //     sourcegraph.languages.registerDefinitionProvider(documentSelector, {
-        //         provideDefinition: distinctUntilChanged(areProviderParamsEqual, (textDocument, position) =>
-        //             observableFromAsyncGenerator(provideDefinition.bind(null, textDocument, position)).pipe(
-        //                 rxop.shareReplay(1)
-        //             )
-        //         ),
-        //     })
-        // )
 
         // References
         const provideReferences = (
@@ -612,210 +566,181 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                     logger.log('References trace', span.generateTraceURL())
                 }
 
-                if (false) {
-                    //     // Gets an opaque value that is the same for all locations
-                    //     // within a file but different from other files.
-                    //     const file = (loc: sourcegraph.Location) => `${loc.uri.host} ${loc.uri.pathname} ${loc.uri.hash}`
-                    //     const lsifReferences = await lsif.references(textDocument, position)
-                    //     const fuzzyReferences = (await basicCodeIntel.references(textDocument, position)) || []
-                    //     const lsifFiles = new Set((lsifReferences ? lsifReferences.value : []).map(file))
-                    //     yield [
-                    //         ...(lsifReferences === undefined ? [] : lsifReferences.value),
-                    //         ...fuzzyReferences
-                    //             .filter(fuzzyRef => !lsifFiles.has(file(fuzzyRef)))
-                    //             .map(v => ({ ...v, badge: impreciseBadge })),
-                    //     ]
-                } else {
-                    const textDocumentUri = new URL(textDocument.uri)
-                    const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
-                    const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
+                const textDocumentUri = new URL(textDocument.uri)
+                const serverRootUri = resolveServerRootUri(textDocumentUri, serverSgEndpoint)
+                const serverTextDocumentUri = toServerTextDocumentUri(textDocumentUri, serverSgEndpoint)
 
-                    const connection = await getOrCreateConnection(serverRootUri, { span, token })
+                const connection = await getOrCreateConnection(serverRootUri, { span, token })
 
-                    const findLocalReferences = () =>
-                        traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
-                            logger.log('Searching for same-repo references')
-                            const localReferences = asArray(
-                                await sendTracedRequest(
-                                    connection,
-                                    ReferencesRequest.type,
-                                    {
-                                        textDocument: { uri: serverTextDocumentUri.href },
-                                        position,
-                                        context,
-                                    },
-                                    { span, tracer, token }
-                                )
+                const findLocalReferences = () =>
+                    traceAsyncGenerator('Find local references', tracer, span, async function*(span) {
+                        logger.log('Searching for same-repo references')
+                        const localReferences = asArray(
+                            await sendTracedRequest(
+                                connection,
+                                ReferencesRequest.type,
+                                {
+                                    textDocument: { uri: serverTextDocumentUri.href },
+                                    position,
+                                    context,
+                                },
+                                { span, tracer, token }
                             )
-                            logger.log(`Found ${localReferences.length} same-repo references`)
-                            yield localReferences
-                        })
-
-                    const findExternalReferences = () =>
-                        traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
-                            try {
-                                logger.log('Getting canonical definition for cross-repo references')
-                                const definition: Location | undefined = asArray((await sendTracedRequest(
-                                    connection,
-                                    DefinitionRequest.type,
-                                    {
-                                        textDocument: { uri: serverTextDocumentUri.href },
-                                        position,
-                                    },
-                                    { span, tracer, token }
-                                )) as Location[] | Location | null)[0]
-                                if (!definition) {
-                                    return
-                                }
-                                span.setTag('uri', redact(definition.uri))
-                                span.setTag('line', definition.range.start.line)
-
-                                const findPackageDependents =
-                                    clientSgEndpoint.url.hostname === 'sourcegraph.com'
-                                        ? findPackageDependentsWithNpm
-                                        : findPackageDependentsWithSourcegraphSearch
-
-                                logger.log(`Getting external references for definition`, definition)
-
-                                const definitionUri = new URL(definition.uri)
-
-                                const referenceParams: ReferenceParams = {
-                                    textDocument: { uri: definitionUri.href },
-                                    position: definition.range.start,
-                                    context: { includeDeclaration: false },
-                                }
-
-                                // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
-                                const clientDefinitionUrl = new URL(definitionUri.href)
-                                clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
-                                clientDefinitionUrl.host = clientSgEndpoint.url.host
-                                const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
-
-                                // Find dependent packages on the package
-                                const dependents =
-                                    packageName === 'sourcegraph'
-                                        ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
-                                          // Extensions are not published to npm, so search the extension registry
-                                          findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
-                                              logger,
-                                              tracer,
-                                              span,
-                                          })
-                                        : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
-
-                                // Search for references in each dependent
-                                const findExternalRefsInDependent = (repoName: string) =>
-                                    traceAsyncGenerator(
-                                        'Find external references in dependent',
-                                        tracer,
-                                        span,
-                                        async function*(span) {
-                                            try {
-                                                logger.log(
-                                                    `Looking for external references in dependent repo ${repoName}`
-                                                )
-                                                span.setTag('repoName', repoName)
-                                                const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
-                                                    span,
-                                                    tracer,
-                                                })
-                                                const rootUri = new URL(
-                                                    `${repoName}@${commitID}/-/raw/`,
-                                                    serverSgEndpoint.url
-                                                )
-                                                if (serverSgEndpoint.accessToken) {
-                                                    rootUri.username = serverSgEndpoint.accessToken
-                                                }
-
-                                                yield await withTempConnection(
-                                                    rootUri,
-                                                    { span, token },
-                                                    async connection => {
-                                                        const references = asArray(
-                                                            await sendTracedRequest(
-                                                                connection,
-                                                                ReferencesRequest.type,
-                                                                referenceParams,
-                                                                {
-                                                                    span,
-                                                                    tracer,
-                                                                    token,
-                                                                }
-                                                            )
-                                                        )
-                                                        logger.log(
-                                                            `Found ${references.length} references in dependent repo ${repoName}`
-                                                        )
-                                                        // Only include references in the external repo, do not duplicate references in the same repo
-                                                        return references.filter(location =>
-                                                            location.uri.startsWith(rootUri.href)
-                                                        )
-                                                    }
-                                                )
-                                            } catch (err) {
-                                                throwIfAbortError(err)
-                                                logErrorEvent(span, err)
-                                                logger.error(
-                                                    `Error searching dependent repo ${repoName} for references`,
-                                                    err
-                                                )
-                                            }
-                                        }
-                                    )
-                                yield* flatMapConcurrent(
-                                    dependents,
-                                    EXTERNAL_REFS_CONCURRENCY,
-                                    findExternalRefsInDependent
-                                )
-                                logger.log('Done going through dependents')
-                            } catch (err) {
-                                logger.error('Could not find external references', err)
-                            }
-                        })
-
-                    yield* merge(findLocalReferences(), findExternalReferences()).pipe(
-                        // Same-repo references
-                        // Cross-repo references
-                        // Find canonical source location
-                        filter(chunk => chunk.length > 0),
-                        tap({
-                            next: chunk => {
-                                span.log({ event: 'chunk', count: chunk.length })
-                            },
-                        }),
-                        // Rewrite URIs and convert from LSP to Sourcegraph Location
-                        map(chunk =>
-                            chunk
-                                .map(location => {
-                                    try {
-                                        return convertLocation({
-                                            ...location,
-                                            uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
-                                        })
-                                    } catch (err) {
-                                        return undefined
-                                    }
-                                })
-                                .filter((location): location is Exclude<typeof location, undefined> => !!location)
-                        ),
-                        // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
-                        scan<sourcegraph.Location[], sourcegraph.Location[]>(
-                            (allReferences, chunk) => allReferences.concat(chunk),
-                            []
                         )
-                    )
-                }
-            })
-        // providers.add(
-        //     sourcegraph.languages.registerReferenceProvider(documentSelector, {
-        //         provideReferences: (doc, pos, ctx) =>
-        //             observableFromAsyncGenerator(provideReferences.bind(null, doc, pos, ctx)),
-        //     })
-        // )
+                        logger.log(`Found ${localReferences.length} same-repo references`)
+                        yield localReferences
+                    })
 
-        // if (config.value['typescript.serverUrl']) {
+                const findExternalReferences = () =>
+                    traceAsyncGenerator('Find external references', tracer, span, async function*(span) {
+                        try {
+                            logger.log('Getting canonical definition for cross-repo references')
+                            const definition: Location | undefined = asArray((await sendTracedRequest(
+                                connection,
+                                DefinitionRequest.type,
+                                {
+                                    textDocument: { uri: serverTextDocumentUri.href },
+                                    position,
+                                },
+                                { span, tracer, token }
+                            )) as Location[] | Location | null)[0]
+                            if (!definition) {
+                                return
+                            }
+                            span.setTag('uri', redact(definition.uri))
+                            span.setTag('line', definition.range.start.line)
+
+                            const findPackageDependents =
+                                clientSgEndpoint.url.hostname === 'sourcegraph.com'
+                                    ? findPackageDependentsWithNpm
+                                    : findPackageDependentsWithSourcegraphSearch
+
+                            logger.log(`Getting external references for definition`, definition)
+
+                            const definitionUri = new URL(definition.uri)
+
+                            const referenceParams: ReferenceParams = {
+                                textDocument: { uri: definitionUri.href },
+                                position: definition.range.start,
+                                context: { includeDeclaration: false },
+                            }
+
+                            // The definition returned by the server points to the server endpoint, rewrite to the client endpoint
+                            const clientDefinitionUrl = new URL(definitionUri.href)
+                            clientDefinitionUrl.protocol = clientSgEndpoint.url.protocol
+                            clientDefinitionUrl.host = clientSgEndpoint.url.host
+                            const packageName = await findPackageName(clientDefinitionUrl, { logger, tracer, span })
+
+                            // Find dependent packages on the package
+                            const dependents =
+                                packageName === 'sourcegraph'
+                                    ? // If the package name is "sourcegraph", we are looking for references to a symbol in the Sourcegraph extension API
+                                      // Extensions are not published to npm, so search the extension registry
+                                      findDependentsWithSourcegraphExtensionRegistry(clientSgEndpoint, {
+                                          logger,
+                                          tracer,
+                                          span,
+                                      })
+                                    : findPackageDependents(packageName, clientSgEndpoint, { logger, tracer, span })
+
+                            // Search for references in each dependent
+                            const findExternalRefsInDependent = (repoName: string) =>
+                                traceAsyncGenerator(
+                                    'Find external references in dependent',
+                                    tracer,
+                                    span,
+                                    async function*(span) {
+                                        try {
+                                            logger.log(`Looking for external references in dependent repo ${repoName}`)
+                                            span.setTag('repoName', repoName)
+                                            const commitID = await resolveRev(repoName, 'HEAD', clientSgEndpoint, {
+                                                span,
+                                                tracer,
+                                            })
+                                            const rootUri = new URL(
+                                                `${repoName}@${commitID}/-/raw/`,
+                                                serverSgEndpoint.url
+                                            )
+                                            if (serverSgEndpoint.accessToken) {
+                                                rootUri.username = serverSgEndpoint.accessToken
+                                            }
+
+                                            yield await withTempConnection(
+                                                rootUri,
+                                                { span, token },
+                                                async connection => {
+                                                    const references = asArray(
+                                                        await sendTracedRequest(
+                                                            connection,
+                                                            ReferencesRequest.type,
+                                                            referenceParams,
+                                                            {
+                                                                span,
+                                                                tracer,
+                                                                token,
+                                                            }
+                                                        )
+                                                    )
+                                                    logger.log(
+                                                        `Found ${references.length} references in dependent repo ${repoName}`
+                                                    )
+                                                    // Only include references in the external repo, do not duplicate references in the same repo
+                                                    return references.filter(location =>
+                                                        location.uri.startsWith(rootUri.href)
+                                                    )
+                                                }
+                                            )
+                                        } catch (err) {
+                                            throwIfAbortError(err)
+                                            logErrorEvent(span, err)
+                                            logger.error(
+                                                `Error searching dependent repo ${repoName} for references`,
+                                                err
+                                            )
+                                        }
+                                    }
+                                )
+                            yield* flatMapConcurrent(dependents, EXTERNAL_REFS_CONCURRENCY, findExternalRefsInDependent)
+                            logger.log('Done going through dependents')
+                        } catch (err) {
+                            logger.error('Could not find external references', err)
+                        }
+                    })
+
+                yield* merge(findLocalReferences(), findExternalReferences()).pipe(
+                    // Same-repo references
+                    // Cross-repo references
+                    // Find canonical source location
+                    filter(chunk => chunk.length > 0),
+                    tap({
+                        next: chunk => {
+                            span.log({ event: 'chunk', count: chunk.length })
+                        },
+                    }),
+                    // Rewrite URIs and convert from LSP to Sourcegraph Location
+                    map(chunk =>
+                        chunk
+                            .map(location => {
+                                try {
+                                    return convertLocation({
+                                        ...location,
+                                        uri: toSourcegraphTextDocumentUri(new URL(location.uri)).href,
+                                    })
+                                } catch (err) {
+                                    return undefined
+                                }
+                            })
+                            .filter((location): location is Exclude<typeof location, undefined> => !!location)
+                    ),
+                    // Aggregate individual chunks into a growing array (which is what Sourcegraph expects)
+                    scan<sourcegraph.Location[], sourcegraph.Location[]>(
+                        (allReferences, chunk) => allReferences.concat(chunk),
+                        []
+                    )
+                )
+            })
+
         // Implementations
-        // const IMPL_ID = 'ts.impl' // implementations panel and provider ID
         const provideImpls = (
             textDocument: sourcegraph.TextDocument,
             position: sourcegraph.Position
@@ -842,17 +767,6 @@ export async function activate(ctx: sourcegraph.ExtensionContext): Promise<void>
                 rewriteUris(implementationResult, toSourcegraphTextDocumentUri)
                 yield convertLocations(implementationResult)
             })
-        // providers.add(
-        //     sourcegraph.languages.registerLocationProvider(IMPL_ID, documentSelector, {
-        //         provideLocations: provideImpls,
-        //     })
-        // )
-        // const panelView = sourcegraph.app.createPanelView(IMPL_ID)
-        // panelView.title = 'Implementations'
-        // panelView.component = { locationProvider: IMPL_ID }
-        // panelView.priority = 160
-        // providers.add(panelView)
-        // }
 
         activateCodeIntel(ctx, documentSelector, handlerArgs, {
             definition: provideDefinition,


### PR DESCRIPTION
This PR cleans up the init code after https://github.com/sourcegraph/sourcegraph-basic-code-intel/pull/198.

This removes all LSIF and search-based logic and instead delegates to the `activateCodeIntel` function, passing it only the language-server specific logic.

This PR will be followed by a major cleanup.